### PR TITLE
update startScriptForJar script gen, dont need -jar imo

### DIFF
--- a/src/main/scala/com/typesafe/startscript/StartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/startscript/StartScriptPlugin.scala
@@ -225,7 +225,7 @@ exit 0
     def startScriptForJarTask(streams: TaskStreams, baseDirectory: File, scriptFile: File, jarFile: File, cpString: RelativeClasspathString) = {
         val template = """#!/bin/bash
 @SCRIPT_ROOT_CHECK@
-java $JAVA_OPTS -cp "@CLASSPATH@" -jar @JARFILE@ "$@"
+java $JAVA_OPTS -cp "@CLASSPATH@" "$@"
 exit 0
 
 """


### PR DESCRIPTION
Remove -jar @JARFILE@ from startScriptsForJarTask, as its currently broken (script points to abs location of the build, whcih may not match where you are running it.), and with that gone you can run multiple main classes from target/start

This script now looks a lot like startScriptForClasses, but not sure if activating startScriptForClasses is possible atm.
