### PR TITLE
Update src/main/scala/com/typesafe/startscript/StartScriptPlugin.scala

### DIFF
--- a/src/main/scala/com/typesafe/startscript/StartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/startscript/StartScriptPlugin.scala
@@ -197,7 +197,7 @@ object StartScriptPlugin extends Plugin {
     }
 
     private def relativeClasspathStringTask(baseDirectory: File, cp: Classpath) = {
-        RelativeClasspathString(cp.files map { f => relativizeFile(baseDirectory, f) } mkString("", ":", ""))
+        RelativeClasspathString(cp.files map { f => relativizeFile(baseDirectory, f) } mkString("", java.io.File.pathSeparator, ""))
     }
 
     // generate shell script that checks we're in the right directory


### PR DESCRIPTION
This alows to run the plugin on windows, testded under http://www.mingw.org/
and should leave other platformd unafected, since unharcodes the OS specific path separator.
