### PR TITLE
Start Java using 'exec' so that monit/god can easily manage it

### DIFF
--- a/src/main/scala/com/typesafe/startscript/StartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/startscript/StartScriptPlugin.scala
@@ -244,9 +244,7 @@ fi
 
 @MAIN_CLASS_SETUP@
 
-java $JAVA_OPTS -cp "@CLASSPATH@" "$MAINCLASS" "$@"
-
-exit 0
+exec java $JAVA_OPTS -cp "@CLASSPATH@" "$MAINCLASS" "$@"
 
 """
         val script = renderTemplate(template, Map("SCRIPT_ROOT_CHECK" -> scriptRootCheck(baseDirectory, scriptFile, None),
@@ -269,8 +267,7 @@ exit 0
 
 @MAIN_CLASS_SETUP@
 
-java $JAVA_OPTS -cp "@CLASSPATH@" "$MAINCLASS" "$@"
-exit 0
+exec java $JAVA_OPTS -cp "@CLASSPATH@" "$MAINCLASS" "$@"
 
 """
 
@@ -314,9 +311,7 @@ if test x"$PORT" = x ; then
     PORT=8080
 fi
 
-java $JAVA_OPTS -Djetty.port="$PORT" -Djetty.home="@JETTY_HOME@" -jar "@JETTY_HOME@/start.jar" "$@"
-
-exit 0
+exec java $JAVA_OPTS -Djetty.port="$PORT" -Djetty.home="@JETTY_HOME@" -jar "@JETTY_HOME@/start.jar" "$@"
 
 """
         val relativeWarFile = relativizeFile(baseDirectory, warFile)


### PR DESCRIPTION
Many process managers send a SIGINT signal to the launched process to kill it. Currently, when this occurs, the start script dies leaving the Java process orphaned.

Simply invoking the Java process using `exec` addresses this problem, since the Java process assumes the same pid as the start script.
