### PR TITLE
Update to comply with plugin guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,26 +21,12 @@ dependencies within your build to work properly.
 
 ## Details
 
-To add the plugin with SBT 0.10.x, use this code to depend on it:
+To use the plugin with SBT 0.12.0 and later:
 
-    resolvers += {
-      val typesafeRepoUrl = new java.net.URL("http://repo.typesafe.com/typesafe/ivy-releases")
-      val pattern = Patterns(false, "[organisation]/[module]/[sbtversion]/[revision]/[type]s/[module](-[classifier])-[revision].[ext]")
-      Resolver.url("Typesafe Ivy Snapshot Repository", typesafeRepoUrl)(pattern)
-    }
-
-    libraryDependencies <<= (libraryDependencies, sbtVersion) { (deps, version) =>
-      deps :+ ("com.typesafe.startscript" %% "xsbt-start-script-plugin" % "0.2.0" extra("sbtversion" -> version))
-    }
-
-With SBT 0.11.x, you can use this simpler code:
-
-    resolvers += Classpaths.typesafeResolver
-
-    addSbtPlugin("com.typesafe.startscript" % "xsbt-start-script-plugin" % "0.5.2")
+    addSbtPlugin("com.typesafe.sbt" % "sbt-start-script % "0.X.Y")
 
 You can place that code in `~/.sbt/plugins/build.sbt` to install the
-plugin globally, or in YOURPROJECT/project/plugins/build.sbt to
+plugin globally, or in `YOURPROJECT/project/plugins.sbt` to
 install the plugin for your project.
 
 If you install the plugin globally, it will add a command
@@ -82,13 +68,34 @@ One way to get a `stage` task that does nothing is:
 
 which sets the `stage` key to `Unit`.
 
+## Migration from earlier versions of xsbt-start-script-plugin
+
+After 0.5.2, the plugin and its APIs were renamed to use
+consistent conventions (matching other plugins). The renamings
+were:
+
+ - the plugin itself is now `sbt-start-script` not
+   `xsbt-start-script-plugin`; update this in your `plugins.sbt`
+ - the Maven group and Java package are now `com.typesafe.sbt`
+   rather than `com.typesafe.startscript`; update this in your
+   `plugins.sbt` and in your build files
+ - the plugin object is now `SbtStartScript` rather than
+   `StartScriptPlugin`, update this in your build files
+ - if you used any keys directly, they are now inside a nested
+   object `StartScriptKeys` so for example rather than writing
+   `startScriptFile` you would write
+   `StartScriptKeys.startScriptFile` _or_ you need to `import
+   StartScriptKeys._`
+
 ## License
 
-xsbt-start-script-plugin is open source software licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
+sbt-start-script is open source software licensed under the
+[Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 ## Contribution policy
 
-Contributions via GitHub pull requests are gladly accepted from their original author.
-Along with any pull requests, please state that the contribution is your original work
-and that you license the work to the xsbt-start-script-plugin project under the project's
-open source license.
+Contributions via GitHub pull requests are gladly accepted from
+their original author.  Before sending the pull request, please
+agree to the Contributor License Agreement at
+http://typesafe.com/contribute/cla (it takes 30 seconds; you use
+your GitHub account to sign the agreement).

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,8 +22,8 @@ object StartScriptBuild extends Build {
             ScalariformKeys.preferences in Compile := formatPrefs,
             ScalariformKeys.preferences in Test    := formatPrefs) ++
         Seq(sbtPlugin := true,
-            organization := "com.typesafe.startscript",
-            name := "xsbt-start-script-plugin",
+            organization := "com.typesafe.sbt",
+            name := "sbt-start-script",
             scalacOptions := Seq("-unchecked", "-deprecation"),
 
             // to release, bump major/minor/micro as appropriate,
@@ -45,8 +45,9 @@ object StartScriptBuild extends Build {
 
             // publish stuff
             publishTo <<= (version) { v =>
-                import Classpaths._
-                Option(if (v endsWith "SNAPSHOT") typesafeSnapshots else typesafeResolver)
+              def scalasbt(repo: String) = ("scalasbt " + repo, "http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-" + repo)
+              val (name, repo) = if (v.endsWith("-SNAPSHOT")) scalasbt("snapshots") else scalasbt("releases")
+              Some(Resolver.url(name, url(repo))(Resolver.ivyStylePatterns))
             },
             publishMavenStyle := false,
             credentials += Credentials(Path.userHome / ".ivy2" / ".typesafe-credentials"))

--- a/src/main/scala/com/typesafe/sbt/SbtStartScript.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtStartScript.scala
@@ -1,4 +1,4 @@
-package com.typesafe.startscript
+package com.typesafe.sbt
 
 import _root_.sbt._
 
@@ -7,7 +7,7 @@ import Keys._
 import Defaults._
 import Scope.GlobalScope
 
-object StartScriptPlugin extends Plugin {
+object SbtStartScript extends Plugin {
     override lazy val settings = Seq(commands += addStartScriptTasksCommand)
 
     case class RelativeClasspathString(value: String)
@@ -19,22 +19,26 @@ object StartScriptPlugin extends Plugin {
 
     ///// Settings keys
 
-    val startScriptFile = SettingKey[File]("start-script-name")
-    val relativeDependencyClasspathString = TaskKey[RelativeClasspathString]("relative-dependency-classpath-string", "Dependency classpath as colon-separated string with each entry relative to the build root directory.")
-    val relativeFullClasspathString = TaskKey[RelativeClasspathString]("relative-full-classpath-string", "Full classpath as colon-separated string with each entry relative to the build root directory.")
-    val startScriptBaseDirectory = SettingKey[File]("start-script-base-directory", "All start scripts must be run from this directory.")
-    val startScriptForWar = TaskKey[File]("start-script-for-war", "Generate a shell script to launch the war file")
-    val startScriptForJar = TaskKey[File]("start-script-for-jar", "Generate a shell script to launch the jar file")
-    val startScriptForClasses = TaskKey[File]("start-script-for-classes", "Generate a shell script to launch from classes directory")
-    val startScriptNotDefined = TaskKey[File]("start-script-not-defined", "Generate a shell script that just complains that the project is not launchable")
-    val startScript = TaskKey[File]("start-script", "Generate a shell script that runs the application")
+    object StartScriptKeys {
+        val startScriptFile = SettingKey[File]("start-script-name")
+        val relativeDependencyClasspathString = TaskKey[RelativeClasspathString]("relative-dependency-classpath-string", "Dependency classpath as colon-separated string with each entry relative to the build root directory.")
+        val relativeFullClasspathString = TaskKey[RelativeClasspathString]("relative-full-classpath-string", "Full classpath as colon-separated string with each entry relative to the build root directory.")
+        val startScriptBaseDirectory = SettingKey[File]("start-script-base-directory", "All start scripts must be run from this directory.")
+        val startScriptForWar = TaskKey[File]("start-script-for-war", "Generate a shell script to launch the war file")
+        val startScriptForJar = TaskKey[File]("start-script-for-jar", "Generate a shell script to launch the jar file")
+        val startScriptForClasses = TaskKey[File]("start-script-for-classes", "Generate a shell script to launch from classes directory")
+        val startScriptNotDefined = TaskKey[File]("start-script-not-defined", "Generate a shell script that just complains that the project is not launchable")
+        val startScript = TaskKey[File]("start-script", "Generate a shell script that runs the application")
 
-    // jetty-related settings keys
-    val startScriptJettyVersion = SettingKey[String]("start-script-jetty-version", "Version of Jetty to use for running the .war")
-    val startScriptJettyChecksum = SettingKey[String]("start-script-jetty-checksum", "Expected SHA-1 of the Jetty distribution we intend to download")
-    val startScriptJettyURL = SettingKey[String]("start-script-jetty-url", "URL of the Jetty distribution to download (if set, then it overrides the start-script-jetty-version)")
-    val startScriptJettyContextPath = SettingKey[String]("start-script-jetty-context-path", "Context path for the war file when deployed to Jetty")
-    val startScriptJettyHome = TaskKey[File]("start-script-jetty-home", "Download Jetty distribution and return JETTY_HOME")
+        // jetty-related settings keys
+        val startScriptJettyVersion = SettingKey[String]("start-script-jetty-version", "Version of Jetty to use for running the .war")
+        val startScriptJettyChecksum = SettingKey[String]("start-script-jetty-checksum", "Expected SHA-1 of the Jetty distribution we intend to download")
+        val startScriptJettyURL = SettingKey[String]("start-script-jetty-url", "URL of the Jetty distribution to download (if set, then it overrides the start-script-jetty-version)")
+        val startScriptJettyContextPath = SettingKey[String]("start-script-jetty-context-path", "Context path for the war file when deployed to Jetty")
+        val startScriptJettyHome = TaskKey[File]("start-script-jetty-home", "Download Jetty distribution and return JETTY_HOME")
+    }
+
+    import StartScriptKeys._
 
     // this is in WebPlugin, but we don't want to rely on WebPlugin to build
     private val packageWar = TaskKey[File]("package-war")

--- a/src/sbt-test/start/00basic/build.sbt
+++ b/src/sbt-test/start/00basic/build.sbt
@@ -1,6 +1,6 @@
-import com.typesafe.startscript.StartScriptPlugin
+import com.typesafe.sbt.SbtStartScript
 
-seq(StartScriptPlugin.startScriptForClassesSettings: _*)
+seq(SbtStartScript.startScriptForClassesSettings: _*)
 
 version := "0.1"
 

--- a/src/sbt-test/start/00basic/project/plugins.sbt
+++ b/src/sbt-test/start/00basic/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.startscript" % "xsbt-start-script-plugin" % "0.5.2-SNAPSHOT")
+addSbtPlugin("com.typesafe.sbt" % "sbt-start-script" % "0.5.3-SNAPSHOT")

--- a/src/sbt-test/start/01jar/build.sbt
+++ b/src/sbt-test/start/01jar/build.sbt
@@ -1,6 +1,6 @@
-import com.typesafe.startscript.StartScriptPlugin
+import com.typesafe.sbt.SbtStartScript
 
-seq(StartScriptPlugin.startScriptForJarSettings: _*)
+seq(SbtStartScript.startScriptForJarSettings: _*)
 
 version := "0.1"
 

--- a/src/sbt-test/start/01jar/project/plugins.sbt
+++ b/src/sbt-test/start/01jar/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.startscript" % "xsbt-start-script-plugin" % "0.5.2-SNAPSHOT")
+addSbtPlugin("com.typesafe.sbt" % "sbt-start-script" % "0.5.3-SNAPSHOT")

--- a/src/sbt-test/start/02war/build.sbt
+++ b/src/sbt-test/start/02war/build.sbt
@@ -1,7 +1,7 @@
-import com.typesafe.startscript.StartScriptPlugin
+import com.typesafe.sbt.SbtStartScript
 import com.github.siasia.WebPlugin
 
-seq(StartScriptPlugin.startScriptForWarSettings: _*)
+seq(SbtStartScript.startScriptForWarSettings: _*)
 
 seq(WebPlugin.webSettings: _*)
 

--- a/src/sbt-test/start/02war/project/plugins.sbt
+++ b/src/sbt-test/start/02war/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.startscript" % "xsbt-start-script-plugin" % "0.5.2-SNAPSHOT")
+addSbtPlugin("com.typesafe.sbt" % "sbt-start-script" % "0.5.3-SNAPSHOT")
 
 libraryDependencies <+= (sbtVersion)(sbtVersion =>
   "com.github.siasia" % "xsbt-web-plugin_2.9.2" % (sbtVersion + "-0.2.11.1")


### PR DESCRIPTION
- move group/package to com.typesafe.sbt
  - rename to sbt-start-script from xsbt-start-script-plugin
  - rename plugin object to SbtStartScript from StartScriptPlugin
  - put keys in a StartScriptKeys object
