### PR TITLE
Fix #30 Uses a script detection that works on OSX as well as Linux

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtStartScript.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtStartScript.scala
@@ -263,7 +263,7 @@ object SbtStartScript extends Plugin {
         }
 
         val templateWindows = """set PROJECT_DIR=%~dp0\@PATH_TO_PROJECT@"""
-        val templateLinux = """PROJECT_DIR=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/@PATH_TO_PROJECT@"""
+        val templateLinux = """PROJECT_DIR=$(cd "${BASH_SOURCE[0]%/*}" && pwd -P)/@PATH_TO_PROJECT@"""
         val template: String = if (isWindows()) templateWindows else templateLinux
         renderTemplate(template, Map("PATH_TO_PROJECT" -> pathFromScriptDirToBaseDir))
     }


### PR DESCRIPTION
Changed to use a more BASH friendly method where it solely
relies on PWD and cd to ascertain the correct path
Works on OSX.
