### PR TITLE
add startScriptArgs setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ following to `build.sbt` after the above import statement:
 
     startScriptName <<= target / "run"
 
+There is also the possibility to define a list of arguments which is always
+passed to the main class, prepended to the arguments specified when running the
+start script:
+
+    startScriptArgs := Seq("one arg", "another")
+
 ## Migration from earlier versions of xsbt-start-script-plugin
 
 After 0.5.2, the plugin and its APIs were renamed to use


### PR DESCRIPTION
This setting allows the build to specify a list of arguments to be
prepended to the command line arguments of the start script before
passing them on to the main class.
