### PR TITLE
Support sym-linked target directory

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtStartScript.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtStartScript.scala
@@ -253,7 +253,7 @@ object SbtStartScript extends Plugin {
     // Generate shell script that calculates path to project directory from its own path.
     private def scriptRootDetect(baseDirectory: File, scriptFile: File, otherFile: Option[File]): String = {
         val baseDir = baseDirectory.getCanonicalPath
-        val scriptDir = scriptFile.getParentFile.getCanonicalPath
+        val scriptDir = scriptFile.getParentFile.getPath
         val pathFromScriptDirToBaseDir = if (scriptDir startsWith (baseDir + File.separator)) {
             val relativePath = scriptDir drop (baseDir.length + 1)
             var parts = relativePath split Pattern.quote(File.separator)


### PR DESCRIPTION
This patch works around a problem that arises when the project target directory is a sym-link to another directory on the file system. I'm not sure if the `baseDir` needs the same treatment or if the `scriptDir` change has any other knock-on effects, but this change was enough to get the plugin working again for me locally.
